### PR TITLE
add securitycontext on pgo-operator deployment

### DIFF
--- a/installers/ansible/roles/pgo-operator/templates/deployment.json.j2
+++ b/installers/ansible/roles/pgo-operator/templates/deployment.json.j2
@@ -25,7 +25,7 @@
             "spec": {
                 "securityContext" : {
                   "runAsUser": "1001"
-                }
+                },
                    
                 "serviceAccountName": "postgres-operator",
                 "containers": [

--- a/installers/ansible/roles/pgo-operator/templates/deployment.json.j2
+++ b/installers/ansible/roles/pgo-operator/templates/deployment.json.j2
@@ -23,6 +23,10 @@
                 }
             },
             "spec": {
+                "securityContext" : {
+                  "runAsUser": "1001"
+                }
+                   
                 "serviceAccountName": "postgres-operator",
                 "containers": [
                     {


### PR DESCRIPTION
Add a securityContext to be able to run operator in case of PodSecurityPolicy with RunAsNonRoot enabled
There is no need to be root.

**Checklist:**

 - [X] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [X] Have you updated or added documentation for the change, as applicable?
not necessary
 - [X] Have you tested your changes on all related environments with successful results, as applicable?


**Type of Changes:**
 - [ ] Bug fix (non-breaking change which fixes an issue)

 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**



**What is the new behavior (if this is a feature change)?**



**Other information**:
